### PR TITLE
Utilisation de la variable d'env APPLICATION_NAME dans les tests

### DIFF
--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -19,7 +19,7 @@ feature 'Signing up:' do
 
     before do
       visit commencer_path(path: procedure.path)
-      click_on 'Créer un compte demarches-simplifiees.fr'
+      click_on "Créer un compte #{APPLICATION_NAME}"
       expect(page).to have_selector('.suspect-email', visible: false)
       fill_in 'Email', with: 'bidou@yahoo.rf'
       fill_in 'Mot de passe', with: '12345'
@@ -49,7 +49,7 @@ feature 'Signing up:' do
 
   scenario 'a new user can’t sign-up with too short password when visiting a procedure' do
     visit commencer_path(path: procedure.path)
-    click_on 'Créer un compte demarches-simplifiees.fr'
+    click_on "Créer un compte #{APPLICATION_NAME}"
 
     expect(page).to have_current_path new_user_registration_path
     sign_up_with user_email, '1234567'

--- a/spec/helpers/conservation_de_donnees_helper_spec.rb
+++ b/spec/helpers/conservation_de_donnees_helper_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe ConservationDeDonneesHelper, type: :helper do
       let(:dans_ds) { 3 }
       let(:hors_ds) { 6 }
 
-      it { is_expected.to eq(["Dans demarches-simplifiees.fr : 3 mois", "Par l’administration : 6 mois"]) }
+      it { is_expected.to eq(["Dans #{APPLICATION_NAME} : 3 mois", "Par l’administration : 6 mois"]) }
     end
 
     context "when only in-app retention time is set" do
       let(:dans_ds) { 3 }
       let(:hors_ds) { nil }
 
-      it { is_expected.to eq(["Dans demarches-simplifiees.fr : 3 mois"]) }
+      it { is_expected.to eq(["Dans #{APPLICATION_NAME} : 3 mois"]) }
     end
 
     context "when only out of app retention time is set" do


### PR DESCRIPTION
# Constat

Lorsque la variable d'environnement `APPLICATION_NAME` est personnalisée avec une valeur différente de `demarches-simplifiees.fr`, certains tests ne passent plus.

# Correctif

Utiliser la variable d'environnement dans les tests, plutôt qu'une valeur fixe, résout le problème.