### PR TITLE
Ajout de l'option no-sandbox pour les tests Capybara

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -12,6 +12,7 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--no-sandbox')
   options.add_argument('--headless')
   options.add_argument('--window-size=1440,900')
 


### PR DESCRIPTION
# Constat

Lors de l'exécution des tests Capybara avec un Chromium _headless_, cette erreur apparait :

```
WebDriverException: unknown error: DevToolsActivePort file doesn't exist 
```

# Correctif

Activer l'option `--no-sandbox` dans la configuration du _driver_ `:headless_chrome` résout le problème.

cf. https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t