### PR TITLE
Les tests sur l'API Universign lèvent une exception si l'URL n'est pas définie

### DIFF
--- a/spec/lib/universign/api_spec.rb
+++ b/spec/lib/universign/api_spec.rb
@@ -4,6 +4,9 @@ describe Universign::API do
 
     let(:digest) { Digest::SHA256.hexdigest("CECI EST UN HASH") }
 
-    it { is_expected.not_to be_nil }
+    it do
+      skip "L'URL de l'API Universign est obligatoire pour effectuer ce test" if UNIVERSIGN_API_URL.blank?
+      is_expected.not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
# Constat

Les tests sur l'API Universign lèvent une exception si la variable d'environnement `UNIVERSIGN_API_URL` n'est pas définie.

```ruby
Addressable::URI::InvalidURIError:
 Absolute URI missing hierarchical segment: 'http://'
```

# Correctif

Court-circuiter le test avec un message explicite permet d'éviter la levée d'exception, sans pour autant passer l'information sous silence.