### PR TITLE
API Entreprise : ajout du support des jetons sans date d'expiration

### DIFF
--- a/app/models/api_entreprise_token.rb
+++ b/app/models/api_entreprise_token.rb
@@ -6,11 +6,15 @@ class APIEntrepriseToken
   end
 
   def roles
-    decoded_token["roles"] if token.present?
+    return [] if token.blank?
+
+    Array(decoded_token["roles"])
   end
 
   def expired?
-    Time.zone.now.to_i >= decoded_token["exp"] if token.present?
+    return false if token.blank? || !decoded_token.key?("exp")
+
+    Time.zone.now.to_i >= decoded_token["exp"]
   end
 
   def role?(role)
@@ -20,6 +24,7 @@ class APIEntrepriseToken
   private
 
   def decoded_token
-    JWT.decode(token, nil, false)[0]
+    @decoded_token ||= {}
+    @decoded_token[token] ||= JWT.decode(token, nil, false)[0]
   end
 end


### PR DESCRIPTION
# Constat

Les jetons JWT peuvent ne pas avoir de clé d'expiration dans leur _payload_.

Par exemple, ce jeton est valide mais n'a pas de clé d'expiration :

```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ey
JzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
G4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKx
wRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
```

Cf. https://jwt.io/

# Ajout fonctionnel

Cette PR ajoute le support de jetons sans clé d'expiration. Pour ce faire, la méthode `expired?` retournera systématiquement faux pour ce type de jeton.

Par aileurs, cette PR assure également que la méthode `roles` retourne toujours un tableau pour éviter les erreurs lorsque son résultat est manipulé par la méthode `role?`