### PR TITLE
Utilisation de la variable d'env APP_HOST en environnement de développement

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -88,17 +88,13 @@ Rails.application.configure do
     }
   else
     config.action_mailer.delivery_method = :letter_opener_web
-    config.action_mailer.default_url_options = {
-      host: 'localhost',
-      port: 3000
-    }
-
-    config.action_mailer.asset_host = "http://" + ENV['APP_HOST']
+    config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "localhost:3000") }
+    config.action_mailer.asset_host = "http://" + ENV.fetch("APP_HOST", "localhost:3000")
   end
 
   Rails.application.routes.default_url_options = {
-    host: 'localhost',
-    port: 3000
+    host: ENV.fetch("APP_HOST", "localhost:3000"),
+    protocol: :http
   }
 
   # Use Content-Security-Policy-Report-Only headers


### PR DESCRIPTION
# Constat

Lorsqu'en environnement de développement, la variable d'environnement `APP_HOST` est personnalisée avec une valeur autre que `localhost:3000`, des erreurs surviennent lors de la construction des routes. 

```
*** ArgumentError Exception: Missing host to link to! Please provide the
   :host parameter, set default_url_options[:host], or set :only_path to true
```

# Correctif

L'utilisation de la variable d'environnement `APP_HOST` pour définir `Rails.application.routes.default_url_options` et la configuration d'`ActionMailer` résout le problème.