### PR TITLE
Ajout du support de l'option --only-failures à RSpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+failing_specs.txt
 
 public/uploads
 public/downloads

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.color = true
   config.tty = true
 
+  config.example_status_persistence_file_path = 'failing_specs.txt'
   config.run_all_when_everything_filtered = true
   config.filter_run :focus => true
 


### PR DESCRIPTION
# Constat

L'exécution de l'ensemble des tests prend un certain temps. 

# Ajout fonctionnel

RSpec propose une option `--only-failures` permettant de garder trace des tests ayant échoué pour ne rejouer que ceux-ci.
Cette PR ajoute le support de cette option en déclarant le nom du fichier qui sera utilisé par RSpec pour ce faire.

## Usage

```
rspec                   # joue tous les tests
rspec --only-failures   # ne rejoue que les tests en échec
```

Cf. https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures