### PR TITLE
Fix les feature tests sur les experts en nettoyant les courriels avant chaque test

### DIFF
--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -10,6 +10,10 @@ feature 'Inviting an expert:', js: true do
   let(:dossier) { create(:dossier, :en_construction, :with_dossier_link, procedure: procedure) }
   let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).map(&:value).compact) }
 
+  background do
+    clear_emails
+  end
+
   context 'as an Instructeur' do
     scenario 'I can invite an expert' do
       allow(ClamavService).to receive(:safe_file?).and_return(true)


### PR DESCRIPTION
# Constat

```
rspec ./spec/features/instructeurs/expert_spec.rb:14

Failures:

  1) Inviting an expert: as an Instructeur I can invite an expert
     Failure/Error: invitation_email = open_email(expert.email.to_s)

Diff:
  -/procedures/2/avis/2/sign_up/email/expert1@expert.com
  +/procedures/1/avis/1/sign_up/email/expert1@expert.com
```

# Correctif

La gem `capybara-email` sur laquelle reposent les _feature tests_ met à disposition une méthode `clear_emails` pour vider la boîte aux lettres. L'appel à cette méthode avant chaque test résout le problème rencontré et fait passer le test incriminé à tous les coups.

Cf. https://github.com/DavyJonesLocker/capybara-email