### PR TITLE
Fix d'un comportement inattendu de RGeo

### DIFF
--- a/app/validators/geo_json_validator.rb
+++ b/app/validators/geo_json_validator.rb
@@ -1,7 +1,7 @@
 class GeoJSONValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     begin
-      RGeo::GeoJSON.decode(value.to_json, geo_factory: RGeo::Geographic.simple_mercator_factory)
+      RGeo::GeoJSON.decode(value.to_json, geo_factory: RGeo::Geographic.spherical_factory)
     rescue RGeo::Error::InvalidGeometry
       record.errors[attribute] << (options[:message] || "n'est pas un GeoJSON valide")
     end


### PR DESCRIPTION
# Constat

```
rspec ./spec/models/geo_area_spec.rb

Failures:

  1) GeoArea#valid? hourglass_polygon is expected to be falsey
     Failure/Error: it { expect(geo_area.valid?).to be_falsey }

       expected: falsey value
            got: true

  2) GeoArea#valid? invalid_right_hand_rule_polygon
     Failure/Error: RGeo::GeoJSON.decode(value.to_json, geo_factory: RGeo::Geographic.simple_mercator_factory)

     NoMethodError:
       undefined method `is_simple?' for nil:NilClass
       Did you mean?  is_haml?
```

Il semble que cela ne se produise que sur macOS. Ça ne semble pas être un problème avec la gem `rgeo`, mais plutôt avec la bibliothèque `geos` sous-jacente sur mac.

Il semble y avoir une différence dans la façon dont geos 3.8.x (et suivantes — 3.9.1 est la dernière version dans Homebrew au 14/04/2021) et les versions précédentes de la bibliothèque geos gèrent le calcul `is_simple?` qui détermine la validité du polygone. Ceci affecte presque toutes les _factories_ RGeo ; la plupart d'entre elles, mais pas `RGeo::Geographic.spherical_factory` ou `RGeo::Cartesian.simple_factory` gérées par CAPI.

# Correctif

Les tests passent de nouveau en replaçant la _factory_ `RGeo::Geographic.simple_mercator_factory` par `RGeo::Geographic.spherical_factory` dans la classe `GeoJSONValidator`.

Cf. https://stackoverflow.com/questions/58996305/getting-invalidgeometry-linearring-failed-ring-test-after-upgrading-rgeo-gem