### PR TITLE
Spécifier l'environnement actuel dans la configuration de Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,7 +244,7 @@ class ApplicationController < ActionController::Base
     sentry = Rails.application.secrets.sentry
 
     {
-      key: sentry[:client_key],
+      key: sentry[:js_client_key],
       enabled: sentry[:enabled],
       environment: sentry[:environment],
       browser: { modern: BrowserSupport.supported?(browser) },

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,10 +1,12 @@
 Sentry.init do |config|
-  config.dsn = ENV['SENTRY_ENABLED'] == 'enabled' ? ENV['SENTRY_DSN_RAILS'] : nil
+  secrets = Rails.application.secrets.sentry
+
+  config.dsn = secrets[:enabled] ? secrets[:rails_client_key] : nil
   config.send_default_pii = false
-  config.environment = ENV.fetch('SENTRY_ENVIRONMENT', Rails.env)
-  config.enabled_environments = ['production', ENV['SENTRY_ENVIRONMENT'].presence].compact
+  config.environment = secrets[:environment] || Rails.env
+  config.enabled_environments = ['production', secrets[:environment].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
-  config.traces_sample_rate = ENV['SENTRY_ENABLED'] == 'enabled' ? 0.001 : nil
+  config.traces_sample_rate = secrets[:enabled] ? 0.001 : nil
   config.excluded_exceptions += [
     # Ignore exceptions caught by ActiveJob.retry_on
     # https://github.com/getsentry/sentry-ruby/issues/1347

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,8 @@
 Sentry.init do |config|
   config.dsn = ENV['SENTRY_ENABLED'] == 'enabled' ? ENV['SENTRY_DSN_RAILS'] : nil
   config.send_default_pii = false
-  config.enabled_environments = ['production']
+  config.environment = ENV.fetch('SENTRY_ENVIRONMENT', Rails.env)
+  config.enabled_environments = ['production', ENV['SENTRY_ENVIRONMENT'].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
   config.traces_sample_rate = ENV['SENTRY_ENABLED'] == 'enabled' ? 0.001 : nil
   config.excluded_exceptions += [

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -50,7 +50,8 @@ defaults: &defaults
     client_key: <%= ENV['MATOMO_ID'] %>
   sentry:
     enabled: <%= ENV['SENTRY_ENABLED'] == 'enabled' %>
-    client_key: <%= ENV['SENTRY_DSN_JS'] %>
+    js_client_key: <%= ENV['SENTRY_DSN_JS'] %>
+    rails_client_key: <%= ENV['SENTRY_DSN_RAILS'] %>
     environment: <%= ENV['SENTRY_CURRENT_ENV'] %>
   crisp:
     enabled: <%= ENV['CRISP_ENABLED'] == 'enabled' %>


### PR DESCRIPTION
# Constat

Les erreurs 500 peuvent ne pas remonter dans Sentry selon la configuration de DS. Il s'avère que le seul environnement activé est `production` et que l'environnement par défaut de Sentry est le même que celui de `RACK_ENV`, et celui-ci n'est pas surchargé.

```ruby
    # RACK_ENV by default.
    attr_reader :environment
```

Cf. https://github.com/getsentry/sentry-ruby/blob/master/sentry-ruby/lib/sentry/configuration.rb#L72-L73

# Correctif

Déclaration de l'environnement de Sentry via une variable d'environnement, ou à défaut la valeur de `Rails.env`.