### PR TITLE
Fix les feature tests sur les filtres de procédures

### DIFF
--- a/spec/features/instructeurs/procedure_filters_spec.rb
+++ b/spec/features/instructeurs/procedure_filters_spec.rb
@@ -47,6 +47,9 @@ feature "procedure filters" do
     end
 
     remove_column(type_de_champ.libelle)
+    # NOTE: Ensure the page is fully reloaded
+    expect(page).to have_current_path(instructeur_procedure_path(procedure))
+
     within ".dossiers-table" do
       expect(page).not_to have_link(type_de_champ.libelle)
       expect(page).not_to have_link(champ.value)


### PR DESCRIPTION
Actuellement :

```
❯ rspec ./spec/features/instructeurs/procedure_filters_spec.rb:42
Run options:
  include {:focus=>true, :locations=>{"./spec/features/instructeurs/procedure_filters_spec.rb"=>[42]}}
  exclude {:disable=>true}

Randomized with seed 5577
F  HTML screenshot: /app/tmp/capybara/screenshot_2021-04-29-13-49-43.264.html
  Image screenshot: /app/tmp/capybara/screenshot_2021-04-29-13-49-43.264.png


Failures:

  1) procedure filters should add be able to add and remove custom type_de_champ column
     Failure/Error: expect(page).not_to have_link(type_de_champ.libelle)
       expected not to find link "Libelle du champ 1" within #<Capybara::Node::Element tag="table" path="/HTML/BODY[1]/DIV[1]/MAIN[1]/DIV[2]/DIV[2]/TABLE[1]">, found 1 match: "Libelle du champ 1"
     # ./spec/features/instructeurs/procedure_filters_spec.rb:51:in `block (3 levels) in <main>'
     # /usr/local/bundle/ruby/2.7.0/gems/capybara-3.35.3/lib/capybara/session.rb:353:in `within'
     # /usr/local/bundle/ruby/2.7.0/gems/capybara-3.35.3/lib/capybara/dsl.rb:53:in `call'
     # /usr/local/bundle/ruby/2.7.0/gems/capybara-3.35.3/lib/capybara/dsl.rb:53:in `within_element'
     # /usr/local/bundle/ruby/2.7.0/gems/capybara-3.35.3/lib/capybara/rspec/matcher_proxies.rb:15:in `within'
     # ./spec/features/instructeurs/procedure_filters_spec.rb:50:in `block (2 levels) in <main>'
     # /usr/local/bundle/ruby/2.7.0/gems/webmock-3.11.2/lib/webmock/rspec.rb:37:in `block (2 levels) in <main>'

Finished in 40.82 seconds (files took 1 minute 8.81 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/features/instructeurs/procedure_filters_spec.rb:42 # procedure filters should add be able to add and remove custom type_de_champ column

Randomized with seed 5577
```

En nous assurons que la page est entièrement rechargée :

```
❯ rspec ./spec/features/instructeurs/procedure_filters_spec.rb:42
Run options:
  include {:focus=>true, :locations=>{"./spec/features/instructeurs/procedure_filters_spec.rb"=>[42]}}
  exclude {:disable=>true}

Randomized with seed 52603
.

Finished in 23.25 seconds (files took 15.28 seconds to load)
1 example, 0 failures

Randomized with seed 52603
```