### PR TITLE
Correction d'une erreur 500 à la validation d'un nouveau dossier

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -350,7 +350,7 @@ class Dossier < ApplicationRecord
   after_create_commit :send_draft_notification_email
 
   validates :user, presence: true, if: -> { deleted_user_email_never_send.nil? }
-  validates :individual, presence: true, if: -> { revision.procedure.for_individual? }
+  validates :individual, presence: true, if: -> { revision&.procedure&.for_individual? }
   validates :groupe_instructeur, presence: true, if: -> { !brouillon? }
 
   def user_deleted?


### PR DESCRIPTION
Rien ne garanti qu'une révision soit liée à un dossier, notamment dans les tests. Cela entraine des erreurs de manière aléatoire lors de l'exécution de ceux-ci.

### Reproduction à l'excution des tests

```
rspec --seed=30644

Failure/Error: validates :individual, presence: true, if: -> { revision.procedure.for_individual? }
           
            NoMethodError:
              undefined method `for_individual?' for nil:NilClass
            # ./app/models/dossier.rb:343:in `block in <class:Dossier>'
            # ./app/controllers/users/dossiers_controller.rb:371:in `update_dossier_and_compute_errors'
            # ./app/controllers/users/dossiers_controller.rb:142:in `update_brouillon'
```

Cf. https://github.com/adullact/demarches-simplifiees.fr/pull/29#issuecomment-827728184

### Reproduction en console

```ruby
# Running via Spring preloader in process 550
# Loading test environment (Rails 6.1.3.1)
irb(main):001:0> Dossier.new.valid?
# Creating scope :en_construction. Overwriting existing method Dossier.en_construction.
# Creating scope :en_instruction. Overwriting existing method Dossier.en_instruction.
# DEPRECATION WARNING: The behavior of the `:interval` type will be changing in Rails 6.2
# to return an `ActiveSupport::Duration` object. If you'd like to keep
# the old behavior, you can add this line to Dossier model:
#
#   attribute :en_construction_conservation_extension, :string
#
# If you'd like the new behavior today, you can add this line:
#
#   attribute :en_construction_conservation_extension, :interval
#  (called from irb_binding at (irb):1)
Traceback (most recent call last):
        2: from (irb):1
        1: from app/models/dossier.rb:343:in `block in <class:Dossier>'
NoMethodError (undefined method `procedure' for nil:NilClass)
irb(main):002:0>
```

Avec le fix :

```ruby
irb(main):003:0> Dossier.new.valid?
=> false
irb(main):004:0>
```