### PR TITLE
Échec aléatoire de tests sur API Entreprise

### DIFF
--- a/spec/jobs/api_entreprise/exercices_job_spec.rb
+++ b/spec/jobs/api_entreprise/exercices_job_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe APIEntreprise::ExercicesJob, type: :job do
 
   it 'updates etablissement' do
     subject
-    expect(Etablissement.find(etablissement.id).exercices[0].ca).to eq('21009417')
+    ca_list = Etablissement.find(etablissement.id).exercices.map(&:ca)
+    expect(ca_list).to contain_exactly('21009417', '18968298', '17768838')
   end
 end


### PR DESCRIPTION
## Constat

```
rspec ./spec/jobs/api_entreprise/exercices_job_spec.rb

  1) APIEntreprise::ExercicesJob updates etablissement
     Failure/Error: expect(Etablissement.find(etablissement.id).exercices[0].ca).to eq('21009417')

       expected: "21009417"
            got: "17768838"

       (compared using ==)
     # ./spec/jobs/api_entreprise/exercices_job_spec.rb:18:in `block (2 levels) in <main>'
```

## Correctif

Ne pas présumer de l'ordre du tableau, vérifier simplement que toutes les valeurs sont présentes. Pour cela RSpec met à disposition un _matcher_ `contain_exactly`.

Doc : https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/contain-exactly-matcher