### PR TITLE
Allow to test 500 error page on development environment

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -2,6 +2,8 @@ class SupportController < ApplicationController
   invisible_captcha only: [:create], on_spam: :redirect_to_root
 
   def index
+    raise 'plop'
+
     setup_context
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,7 +17,8 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
+  # config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.


### PR DESCRIPTION
Allow to test 500 error page on development environment

With this PR, the following URL will return an error 500
(currently, it will display the error page public/500.html and return HTTP code 500).
> `http://localhost:3000/contact`